### PR TITLE
Add MAML

### DIFF
--- a/src/max/loss.py
+++ b/src/max/loss.py
@@ -1,0 +1,15 @@
+import jax
+import jax.numpy as jnp
+import optax
+
+@jax.jit
+def task_loss(model, batch):
+    """Calculates loss for a single classification task."""
+    x, labels = batch
+    logits = model(x)
+
+    return jnp.mean(
+        optax.softmax_cross_entropy(
+            logits=logits, labels=jax.nn.one_hot(labels, num_classes=ways)
+        )
+    )  # Use MSE, for example, for regression.

--- a/src/max/maml.py
+++ b/src/max/maml.py
@@ -1,0 +1,37 @@
+import numpy as np
+from functools import partial
+
+import jax
+from flax import nn, optim
+
+from loss import task_loss
+
+
+@jax.jit
+def maml_fit_task(model, batch):
+    """Performs fast adaptation on support set.
+
+    Parameters
+    ----------
+    model: flax.nn.Model
+        A Flax model object.
+    batch: tuple
+        Batch of data of a task: (X, y). This is the support set.
+    inner_optimizer_def: flax.optim.Optimizer
+        Optimizer to use for fast adaptation steps.
+
+    Returns
+    -------
+    updated_model: flax.nn.Model
+        After applying the inner adaptation step.
+
+    """
+    maml_lr = 0.001  # TODO: Allow this as an argument.
+    inner_optimizer_def = optim.GradientDescent(learning_rate=maml_lr)
+
+    model_grad = jax.grad(task_loss)(model, batch)
+    # Create a new optimizer for the given `model`. This is analogous to creating a learner for each task using `.clone()`.
+    inner_opt = inner_optimizer_def.create(model)
+    for _ in range(fas):  # Do fast adaptation for `fas` number of times.
+        inner_opt = inner_opt.apply_gradient(model_grad)  # Analogous to `learner.adapt` step from `learn2learn`.
+    return inner_opt.target  # return the updated model which is stored as an attribute of the updated optimizer.

--- a/src/max/metrics.py
+++ b/src/max/metrics.py
@@ -1,0 +1,7 @@
+import jax
+import jax.numpy as jnp
+
+@jax.jit
+def task_accuracy(logits, labels):
+    """Calculates classification accuracy for a task."""
+    return jnp.mean(jnp.argmax(logits, -1) == labels)

--- a/src/max/opti_trainer.py
+++ b/src/max/opti_trainer.py
@@ -1,0 +1,75 @@
+import jax
+import jax.numpy as jnp
+
+from loss import task_loss
+
+@jax.jit
+def train_step(optimizer, batch, fit_task):
+    """Perform the training step used for each epoch.
+
+    Parameters
+    ----------
+    optimizer: flax.optim.Optimizer
+        An optimizer object.
+    batch: tuple
+        A batch of tasks: (X_adap, y_adap, X_eval, y_eval)
+    fit_task: A callable that fits on a given task and returns the updated model.
+
+    Returns
+    -------
+    optimizer: flax.optim.Optimizer
+        The updated optimizer object.
+    loss: float
+        Loss for an epoch.
+
+    """
+    model = optimizer.target
+
+    @jax.jit
+    def loss(model, train_x, train_y, val_x, val_y):
+        """Calculates loss on the query set after fitting `model` to the support set.
+
+        Parameters
+        ----------
+        model: flax.nn.Model
+        train_x, train_y: Support set for a single task.
+        val_x, val_y: Query set for a single task.
+
+        Returns
+        -------
+        loss: float
+            Task loss.
+
+        """
+        train_batch = (train_x, train_y)
+        val_batch = (val_x, val_y)
+        # Fast adaptation (inner loop)
+        # TODO: Allow *args/**kwargs for `fit_task`.
+        updated_model = fit_task(model, train_batch)
+        # Evaluate on query set to get the loss on the query set.
+        loss = task_loss(updated_model, val_batch)
+        return loss
+
+    @jax.jit
+    def loss_fn(model):
+        """
+        Parameters
+        ----------
+        model: flax.nn.Model
+
+        Returns
+        -------
+        Mean of task losses.
+
+        """
+        train_x, train_y, val_x, val_y = batch
+        task_losses = jax.vmap(partial(loss, model))(  # Apply the `loss` function to each task. `vmap` is used to apply it on all tasks.
+            train_x, train_y, val_x, val_y
+        )
+        return jnp.mean(task_losses)
+
+    loss, grad = jax.value_and_grad(loss_fn)(model)
+    # `apply_gradient` returns a new `Optimizer` instance with the updated target and optimizer state.
+    optimizer = optimizer.apply_gradient(grad)
+
+    return optimizer, loss


### PR DESCRIPTION
Currently, the `task_accuracy` and `task_loss` functions assume classification. Probably better to keep them separate.

---

Maybe a topic for a separate issue: Would be helpful to simultaneously work on developing methods for creating and sampling tasks that do not use `learn2learn`.

Any ideas @veds12 ?