### PR TITLE
Shifted existing implementations to Optax and implemented Meta SGD

### DIFF
--- a/jeta/loss.py
+++ b/jeta/loss.py
@@ -1,16 +1,4 @@
-import jax
 import jax.numpy as jnp
-import optax
 
-
-@jax.jit
-def task_loss(model, batch, ways):
-    """Calculates loss for a single classification task."""
-    x, labels = batch
-    logits = model(x)
-
-    return jnp.mean(
-        optax.softmax_cross_entropy(
-            logits=logits, labels=jax.nn.one_hot(labels, num_classes=ways)
-        )
-    )  # Use MSE, for example, for regression.
+def mse(logits, targets) -> jnp.ndarray:
+    return jnp.mean(jnp.square(logits - targets))

--- a/jeta/loss.py
+++ b/jeta/loss.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
 
+
 def mse(logits, targets) -> jnp.ndarray:
     return jnp.mean(jnp.square(logits - targets))

--- a/jeta/maml.py
+++ b/jeta/maml.py
@@ -1,40 +1,70 @@
 import jax
-from flax import optim
+import jax.numpy as jnp
+from flax import core
+from flax import linen as nn
 
-from jeta.loss import task_loss
+# from loss import mse
+
+from typing import Any, Callable, Tuple
 
 
-@jax.jit
-def maml_fit_task(model, batch):
-    """Performs fast adaptation on support set.
+def maml_adapt(
+    params: core.FrozenDict[str, Any],
+    apply_fn: Callable[[core.FrozenDict[str, Any], jnp.ndarray], jnp.ndarray],
+    loss_fn: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray],
+    support_set: Tuple[jnp.ndarray, jnp.ndarray]
+    ) -> core.FrozenDict[str, Any]:
 
-    Parameters
-    ----------
-    model: flax.nn.Model
-        A Flax model object.
-    batch: tuple
-        Batch of data of a task: (X, y). This is the support set.
-    inner_optimizer_def: flax.optim.Optimizer
-        Optimizer to use for fast adaptation steps.
+    """Adapts with respect to the support set using the MAML algorithm.
 
-    Returns
-    -------
-    updated_model: flax.nn.Model
-        After applying the inner adaptation step.
+    Paper: https://arxiv.org/abs/1703.03400
 
+    Args:
+        params: The parameters of the model.
+        apply_fn: A function that applies the model to a batch of data.
+        loss_fn: A function that computes the loss of a batch of data.
+        support_set: A tuple of (x_train, y_train).
+
+    Returns:
+        adapted_params: adapted parameters
     """
-    maml_lr = 0.001  # TODO: Allow this as an argument.
-    fas = 5
-    inner_optimizer_def = optim.GradientDescent(learning_rate=maml_lr)
 
-    model_grad = jax.grad(task_loss)(model, batch)
-    # Create a new optimizer for the given `model`.
-    # This is analogous to creating a learner for each task using `.clone()`.
-    inner_opt = inner_optimizer_def.create(model)
-    for _ in range(fas):  # Do fast adaptation for `fas` number of times.
-        inner_opt = inner_opt.apply_gradient(
-            model_grad
-        )  # Analogous to `learner.adapt` step from `learn2learn`.
-    return (
-        inner_opt.target
-    )  # return the updated model stored as an attribute of the updated optimizer.
+    theta = params['params']
+
+    maml_lr = 0.01 # Inner Learning rate. TODO: take this parameter as an argument
+    fas = 1 # Fast adaptation steps. TODO: take this parameter as an argument
+
+    def loss(theta, batch):
+        x_train, y_train = batch
+        logits = apply_fn({'params': theta}, x_train)
+        return loss_fn(logits, y_train)
+    
+    for _ in range(fas):
+        grads = jax.grad(loss)(theta, support_set)
+        theta = jax.tree_util.tree_map(lambda t, g: t - maml_lr*g, theta, grads)
+
+    return theta
+
+
+def maml_init(model: nn.Module, init_key, arr: jnp.ndarray):
+    """Initializes the parameters of the model.
+
+    The default parameters initilized by flax don't convege for
+    optimization based meta learning algorithms.
+    Hence they are scaled to match a normal distribution with mean 0 and std 0.01.
+
+    Args:
+        model (nn.Module): model whose parameters are to be initialised
+        init_key (random.PRNGKey): PRNG Key used for initialisation
+        arr (jnp.ndarray): a random array used to initialize the parameters
+
+    Returns:
+        Parameters: A frozen dict of model parameters.
+    """
+
+    EPSILON = 1e-8 # to avoid division by zero
+    params = model.init(init_key, arr).unfreeze()
+    # Paramters are scaled to match a normal distribution with mean 0 and std 0.01
+    params = jax.tree_util.tree_map(lambda p: 0.01*(p-p.mean())/(p.std()+EPSILON), params)
+    params = core.frozen_dict.freeze(params)
+    return params

--- a/jeta/meta_sgd.py
+++ b/jeta/meta_sgd.py
@@ -28,18 +28,29 @@ def meta_sgd_adapt(
         adapted_params: adapted parameters
     """
 
-    theta = params["params"]
-    alpha = params["alpha"]
+    theta, alpha = params["params"].pop("alpha")
+    mutable_params = [key for key in params if key != "params"]
+    # alpha = params['params']['alpha']
+    # Remove 'alpha' from the the parameter list
+    # params = params.unfreeze()
+    # params['params'].pop('alpha')
+    # params = core.frozen_dict.freeze(params)
+    # alpha = params["alpha"]
 
     def loss(theta, batch):
         x_train, y_train = batch
-        logits = apply_fn({"params": theta}, x_train)
-        return loss_fn(logits, y_train)
+        logits, new_mutable_param_values = apply_fn(
+            params.copy({"params": theta}), x_train, train=True, mutable=mutable_params
+        )
+        return loss_fn(logits, y_train), new_mutable_param_values
 
     fas = 1  # Fast adaptation steps. TODO: take this parameter as an argument
 
     for _ in range(fas):
-        grads = jax.grad(loss)(theta, support_set)
+        grads, new_mutable_param_values = jax.grad(loss, has_aux=True)(
+            theta, support_set
+        )
+        params = params.copy(new_mutable_param_values)
         theta = jax.tree_util.tree_map(lambda t, g, a: t - a * g, theta, grads, alpha)
 
     return theta
@@ -65,12 +76,12 @@ def meta_sgd_init(model, init_key, arr):
         Parameters: A frozen dict of model parameters.
     """
 
-    EPSILON = 1e-8
+    # EPSILON = 1e-8
     params = model.init(init_key, arr).unfreeze()
     alpha = jax.tree_util.tree_map(lambda t: jnp.ones_like(t) * 0.01, params["params"])
-    params = jax.tree_util.tree_map(
-        lambda p: 0.01 * (p - p.mean()) / (p.std() + EPSILON), params
-    )
-    params["alpha"] = alpha
+    # params = jax.tree_util.tree_map(
+    #     lambda p: 0.01 * (p - p.mean()) / (p.std() + EPSILON), params
+    # )
+    params["params"]["alpha"] = alpha
     params = core.frozen_dict.freeze(params)
     return params

--- a/jeta/opti_trainer.py
+++ b/jeta/opti_trainer.py
@@ -70,7 +70,7 @@ class OptiTrainer:
 
         Args:
             state (MetaTrainState): Contains information regarding the current state.
-            tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be trained on.
+            tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be evaluated on.
 
         Returns:
             jnp.ndarray: Loss.
@@ -95,7 +95,7 @@ class OptiTrainer:
             adapt_fn ((params, apply_fn, loss_fn, support_set) -> adapted_params): Specific meta learning function
             which adapts to the support set.
             loss_fn ((logits, targets) -> loss): Loss Function.
-            tx (Optax Optimizer): Optax optimizer.
+            tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be trained on
 
         Returns:
             jnp.ndarray: Loss of the task.

--- a/jeta/opti_trainer.py
+++ b/jeta/opti_trainer.py
@@ -1,10 +1,12 @@
-from typing import Callable, Tuple
+from functools import partial
+from typing import Callable, List, Tuple
 
 import jax
 from flax import struct
 from flax.training import train_state
 from jax.numpy import ndarray
 
+import optax
 
 class MetaTrainState(train_state.TrainState):
     adapt_fn: Callable = struct.field(pytree_node=False)
@@ -28,13 +30,15 @@ class OptiTrainer:
             MetaTrainState: Initialized MetaTrainState object.
         """
 
-        return MetaTrainState.create(
+        state = MetaTrainState.create(
             params=params, apply_fn=apply_fn, adapt_fn=adapt_fn, loss_fn=loss_fn, tx=tx
         )
+        return state.replace(opt_state=tx.init(params['params']))
 
     @staticmethod
     @jax.jit
-    def meta_train_step(state: MetaTrainState, tasks) -> Tuple[MetaTrainState, ndarray]:
+    # @partial(jax.jit, static_argnums=(2,))
+    def meta_train_step(state: MetaTrainState, tasks) -> Tuple[MetaTrainState, ndarray, List[ndarray]]:
         """Performs a single meta-training step on a batch of tasks.
 
         The fuctions first adapts to the support set and then evaluates it's perfomance
@@ -43,26 +47,41 @@ class OptiTrainer:
         Args:
             state (MetaTrainState): Contains information regarding the current state.
             tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be trained on.
+            metrics (List[(ndarray, ndarray) -> ndarray]): List of metrics to be evaluated on the query set.
 
         Returns:
-            Tuple[MetaTrainState, jnp.ndarray]: (Next_State, Loss).
+            Tuple[MetaTrainState, jnp.ndarray, List[jnp.ndarray]]: (Next_State, Loss, metrics).
         """
 
-        def batch_meta_train_loss(params, apply_fn, adapt_fn, loss_fn, tasks):
+        params = state.params
+        theta = params["params"]
+        
+        def batch_meta_train_loss(theta, apply_fn, adapt_fn, loss_fn, tasks):
             loss = jax.vmap(OptiTrainer.meta_loss, in_axes=(None, None, None, None, 0))(
-                params, apply_fn, adapt_fn, loss_fn, tasks
+                params.copy({'params': theta}), apply_fn, adapt_fn, loss_fn, tasks
             )
-            return loss.mean()
+            return loss.mean()#, [metric.mean() for metric in metrics_value]
 
         loss, grads = jax.value_and_grad(batch_meta_train_loss)(
-            state.params, state.apply_fn, state.adapt_fn, state.loss_fn, tasks
+            theta, state.apply_fn, state.adapt_fn, state.loss_fn, tasks
         )
-        state = state.apply_gradients(grads=grads)
+        # state = state.apply_gradients(grads=grads)
+
+        # if state.step == 0: # Initialize optimizer
+        #     state = state.replace(opt_state=state.tx.init(state.params["params"]))
+
+        updates, new_opt_state = state.tx.update(grads, state.opt_state, state.params['params'])
+        new_params = optax.apply_updates(state.params['params'], updates)
+        params = state.params.copy({'params': new_params})
+
+        state = state.replace(step=state.step+1, params=params, opt_state=new_opt_state)
+
         return state, loss
 
     @staticmethod
     @jax.jit
-    def meta_test_step(state: MetaTrainState, tasks) -> ndarray:
+    # @partial(jax.jit, static_argnums=(2,))
+    def meta_test_step(state: MetaTrainState, tasks) -> Tuple[ndarray, List[ndarray]]:
         """Performs a single meta-testing step on a batch of tasks.
 
         The function first adapts to the support set and then evaluates it's perfomance
@@ -71,11 +90,13 @@ class OptiTrainer:
         Args:
             state (MetaTrainState): Contains information regarding the current state.
             tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be evaluated on.
+            metrics (List[(ndarray, ndarray) -> ndarray]): List of metrics to be evaluated on the query set.
 
         Returns:
-            jnp.ndarray: Loss.
-
+            Tuple[jnp.ndarray, List[jnp.ndarray]: (Loss, metrics).
         """
+        # , metrics: List[Callable[[ndarray, ndarray], ndarray]]=[]
+
         params = state.params
         apply_fn = state.apply_fn
         loss_fn = state.loss_fn
@@ -83,10 +104,10 @@ class OptiTrainer:
         loss = jax.vmap(OptiTrainer.meta_loss, in_axes=(None, None, None, None, 0))(
             params, apply_fn, adapt_fn, loss_fn, tasks
         )
-        return loss.mean()
+        return loss.mean()#, [metric.mean() for metric in metrics_value]
 
     @staticmethod
-    def meta_loss(params, apply_fn, adapt_fn, loss_fn, task) -> ndarray:
+    def meta_loss(params, apply_fn, adapt_fn, loss_fn, task) -> Tuple[ndarray, List[ndarray]]:
         """Calculates the Meta Loss of a task
 
         Args:
@@ -98,7 +119,7 @@ class OptiTrainer:
             tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be trained on
 
         Returns:
-            jnp.ndarray: Loss of the task.
+            Tuple[jnp.ndarray, List[jnp.ndarray]: (Loss, metrics).
         """
         support_set, query_set = task
 
@@ -107,5 +128,9 @@ class OptiTrainer:
 
         # Evaluation step
         x_train, y_train = query_set
-        logits = apply_fn({"params": theta}, x_train)
-        return loss_fn(logits, y_train).mean()
+        logits = apply_fn(params.copy({'params': theta}), x_train, train=False)
+
+        # Calculate metrics
+        # metrics_value = [metric(logits, y_train) for metric in metrics]
+
+        return loss_fn(logits, y_train)

--- a/jeta/opti_trainer.py
+++ b/jeta/opti_trainer.py
@@ -2,11 +2,11 @@ from functools import partial
 from typing import Callable, List, Tuple
 
 import jax
+import optax
 from flax import struct
 from flax.training import train_state
 from jax.numpy import ndarray
 
-import optax
 
 class MetaTrainState(train_state.TrainState):
     adapt_fn: Callable = struct.field(pytree_node=False)
@@ -33,12 +33,15 @@ class OptiTrainer:
         state = MetaTrainState.create(
             params=params, apply_fn=apply_fn, adapt_fn=adapt_fn, loss_fn=loss_fn, tx=tx
         )
-        return state.replace(opt_state=tx.init(params['params']))
+        return state.replace(opt_state=tx.init(params["params"]))
 
     @staticmethod
-    @jax.jit
-    # @partial(jax.jit, static_argnums=(2,))
-    def meta_train_step(state: MetaTrainState, tasks) -> Tuple[MetaTrainState, ndarray, List[ndarray]]:
+    @partial(jax.jit, static_argnums=(2,))
+    def meta_train_step(
+        state: MetaTrainState,
+        tasks,
+        metrics: List[Callable[[ndarray, ndarray], ndarray]] = [],
+    ) -> Tuple[MetaTrainState, ndarray, List[ndarray]]:
         """Performs a single meta-training step on a batch of tasks.
 
         The fuctions first adapts to the support set and then evaluates it's perfomance
@@ -55,33 +58,47 @@ class OptiTrainer:
 
         params = state.params
         theta = params["params"]
-        
-        def batch_meta_train_loss(theta, apply_fn, adapt_fn, loss_fn, tasks):
-            loss = jax.vmap(OptiTrainer.meta_loss, in_axes=(None, None, None, None, 0))(
-                params.copy({'params': theta}), apply_fn, adapt_fn, loss_fn, tasks
-            )
-            return loss.mean()#, [metric.mean() for metric in metrics_value]
 
-        loss, grads = jax.value_and_grad(batch_meta_train_loss)(
-            theta, state.apply_fn, state.adapt_fn, state.loss_fn, tasks
-        )
+        def batch_meta_train_loss(theta, apply_fn, adapt_fn, loss_fn, tasks):
+            loss, metrics_value = jax.vmap(
+                OptiTrainer.meta_loss, in_axes=(None, None, None, None, 0, None)
+            )(
+                params.copy({"params": theta}),
+                apply_fn,
+                adapt_fn,
+                loss_fn,
+                tasks,
+                metrics,
+            )
+            return loss.mean(), [metric.mean() for metric in metrics_value]
+
+        (loss, metrics_value), grads = jax.value_and_grad(
+            batch_meta_train_loss, has_aux=True
+        )(theta, state.apply_fn, state.adapt_fn, state.loss_fn, tasks)
         # state = state.apply_gradients(grads=grads)
 
         # if state.step == 0: # Initialize optimizer
         #     state = state.replace(opt_state=state.tx.init(state.params["params"]))
 
-        updates, new_opt_state = state.tx.update(grads, state.opt_state, state.params['params'])
-        new_params = optax.apply_updates(state.params['params'], updates)
-        params = state.params.copy({'params': new_params})
+        updates, new_opt_state = state.tx.update(
+            grads, state.opt_state, state.params["params"]
+        )
+        new_params = optax.apply_updates(state.params["params"], updates)
+        params = state.params.copy({"params": new_params})
 
-        state = state.replace(step=state.step+1, params=params, opt_state=new_opt_state)
+        state = state.replace(
+            step=state.step + 1, params=params, opt_state=new_opt_state
+        )
 
-        return state, loss
+        return state, loss, metrics_value
 
     @staticmethod
-    @jax.jit
-    # @partial(jax.jit, static_argnums=(2,))
-    def meta_test_step(state: MetaTrainState, tasks) -> Tuple[ndarray, List[ndarray]]:
+    @partial(jax.jit, static_argnums=(2,))
+    def meta_test_step(
+        state: MetaTrainState,
+        tasks,
+        metrics: List[Callable[[ndarray, ndarray], ndarray]] = [],
+    ) -> Tuple[ndarray, List[ndarray]]:
         """Performs a single meta-testing step on a batch of tasks.
 
         The function first adapts to the support set and then evaluates it's perfomance
@@ -95,19 +112,20 @@ class OptiTrainer:
         Returns:
             Tuple[jnp.ndarray, List[jnp.ndarray]: (Loss, metrics).
         """
-        # , metrics: List[Callable[[ndarray, ndarray], ndarray]]=[]
 
         params = state.params
         apply_fn = state.apply_fn
         loss_fn = state.loss_fn
         adapt_fn = state.adapt_fn
-        loss = jax.vmap(OptiTrainer.meta_loss, in_axes=(None, None, None, None, 0))(
-            params, apply_fn, adapt_fn, loss_fn, tasks
-        )
-        return loss.mean()#, [metric.mean() for metric in metrics_value]
+        loss, metrics_value = jax.vmap(
+            OptiTrainer.meta_loss, in_axes=(None, None, None, None, 0, None)
+        )(params, apply_fn, adapt_fn, loss_fn, tasks, metrics)
+        return loss.mean(), [metric.mean() for metric in metrics_value]
 
     @staticmethod
-    def meta_loss(params, apply_fn, adapt_fn, loss_fn, task) -> Tuple[ndarray, List[ndarray]]:
+    def meta_loss(
+        params, apply_fn, adapt_fn, loss_fn, task, metrics
+    ) -> Tuple[ndarray, List[ndarray]]:
         """Calculates the Meta Loss of a task
 
         Args:
@@ -128,9 +146,9 @@ class OptiTrainer:
 
         # Evaluation step
         x_train, y_train = query_set
-        logits = apply_fn(params.copy({'params': theta}), x_train, train=False)
+        logits = apply_fn(params.copy({"params": theta}), x_train, train=False)
 
         # Calculate metrics
-        # metrics_value = [metric(logits, y_train) for metric in metrics]
+        metrics_value = [metric(logits, y_train) for metric in metrics]
 
-        return loss_fn(logits, y_train)
+        return loss_fn(logits, y_train), metrics_value


### PR DESCRIPTION
Fixes #17
Fixes #15 

- Optax optimizers are used instead of flax.optim. 
- Added Meta SGD. 

---
Example Code Usage:
```python
import flax.linen as nn
class MLP(nn.Module):
    @nn.compact:
    def __call__(self, x, train=True):
        return nn.Dense(10)(x)
```
```python
from opti_trainer import OptiTrainer
from maml import maml_adapt

params = mlp.init(init_key, init_arr)
tx = optax.sgd(0.01) # Outer optimizer
state = OptiTrainer.create(params=params, apply_fn=mlp.apply, adapt_fn=maml_adapt, loss_fn=mse, tx=tx)

for epoch in range(100):
    total_loss = []
    for tasks in task_loader:
        state, loss, metrics_arr = OptiTrainer.meta_train_step(state, tasks, metrics=(accuracy, f1_score))
        total_loss.append(loss)
    loss = jnp.mean(jnp.stack(total_loss))
    print(f'Epoch {epoch+1}/{100}: {loss}')
```