### PR TITLE
Add CNP

### DIFF
--- a/jeta/cnp.py
+++ b/jeta/cnp.py
@@ -1,0 +1,119 @@
+from functools import partial
+from typing import Callable, List, Tuple
+
+import jax
+from flax.training.train_state import TrainState
+from jax.numpy import ndarray
+
+
+class ModelTrainer:
+    @staticmethod
+    @partial(jax.jit, static_argnums=(3, 4))
+    def meta_train_step(
+        encoder_state: TrainState,
+        decoder_state: TrainState,
+        tasks,
+        loss_fn: Callable[[ndarray, ndarray], ndarray],
+        metrics: List[Callable[[ndarray, ndarray], ndarray]] = [],
+    ) -> Tuple[TrainState, TrainState, ndarray, List[ndarray]]:
+        """Performs a single meta-training step on a batch of tasks.
+
+        The fuctions first adapts to the support set and then evaluates it's perfomance
+        on the query set.
+
+        Args:
+            encoder_state (TrainState): Contains information regarding the current encoder state.
+            decoder_state (TrainState): Contains information regarding the current decoder state.
+            tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be evaluated on.
+            loss_fn ((logits, targets) -> loss): Loss Function.
+            metrics (Tuple[(ndarray, ndarray) -> ndarray]): Tuple of metrics to be evaluated on the query set.
+
+        Returns:
+            Tuple[TrainState, TrainState, jnp.ndarray, List[jnp.ndarray]]: (Next_Encoder_State, Next_Decoder_State, Loss, metrics).
+        """
+
+        def batch_meta_train_loss(encoder_params, decoder_params):
+            batch_encoder_state = encoder_state.replace(params=encoder_params)
+            batch_decoder_state = decoder_state.replace(params=decoder_params)
+
+            loss, metrics_value = jax.vmap(
+                ModelTrainer.meta_loss,
+                in_axes=(None, None, None, 0, None, None),
+            )(batch_encoder_state, batch_decoder_state, loss_fn, tasks, metrics, True)
+            return loss.mean(), [metric.mean() for metric in metrics_value]
+
+        (loss, metrics_value), (encoder_grads, decoder_grads) = jax.value_and_grad(
+            batch_meta_train_loss, argnums=(0, 1), has_aux=True
+        )(encoder_state.params, decoder_state.params)
+
+        encoder_state = encoder_state.apply_gradients(grads=encoder_grads)
+        decoder_state = decoder_state.apply_gradients(grads=decoder_grads)
+
+        return encoder_state, decoder_state, loss, metrics_value
+
+    @staticmethod
+    @partial(jax.jit, static_argnums=(3, 4))
+    def meta_test_step(
+        encoder_state: TrainState,
+        decoder_state: TrainState,
+        tasks,
+        loss_fn: Callable[[ndarray, ndarray], ndarray],
+        metrics: List[Callable[[ndarray, ndarray], ndarray]] = [],
+    ) -> Tuple[ndarray, List[ndarray]]:
+        """Performs a single meta-testing step on a batch of tasks.
+
+        The function first adapts to the support set and then evaluates it's perfomance
+        on the query set.
+
+        Args:
+            encoder_state (TrainState): Contains information regarding the current encoder state.
+            decoder_state (TrainState): Contains information regarding the current decoder state.
+            tasks ((x_train, y_train), (x_test, y_test)): Batch of tasks to be evaluated on.
+            loss_fn ((logits, targets) -> loss): Loss Function.
+            metrics (Tuple[(ndarray, ndarray) -> ndarray]): Tuple of metrics to be evaluated on the query set.
+
+        Returns:
+            Tuple[jnp.ndarray, List[jnp.ndarray]: (Loss, metrics).
+        """
+
+        loss, metrics_value = jax.vmap(
+            ModelTrainer.meta_loss,
+            in_axes=(None, None, None, 0, None, None),
+        )(encoder_state, decoder_state, loss_fn, tasks, metrics, False)
+        return loss.mean(), [metric.mean() for metric in metrics_value]
+
+    @staticmethod
+    def meta_loss(
+        encoder_state: TrainState,
+        decoder_state: TrainState,
+        loss_fn,
+        task,
+        metrics,
+        train,
+    ) -> Tuple[ndarray, List[ndarray]]:
+        """Calculates the Meta Loss of a task
+
+        Args:
+            encoder_state (TrainState): Contains information regarding the current encoder state.
+            decoder_state (TrainState): Contains information regarding the current decoder state.
+            loss_fn ((logits, targets) -> loss): Loss Function.
+            task ((x_train, y_train), (x_test, y_test)): Task to be evaluated on.
+            metrics (Tuple[(ndarray, ndarray) -> ndarray]): Tuple of metrics to be evaluated on the query set.
+            train (bool): Whether the encoder/decoder functions are in train/test mode.
+
+        Returns:
+            Tuple[jnp.ndarray, List[jnp.ndarray]]: (Loss, metrics).
+        """
+        support_set, query_set = task
+
+        # Adaptation step
+        r = encoder_state.apply_fn(encoder_state.params, *support_set, train=train)
+
+        # Evaluation step
+        x_test, y_test = query_set
+        logits = decoder_state.apply_fn(decoder_state.params, r, x_test, train=train)
+
+        # Calculate metrics
+        metrics_value = [metric(logits, y_test) for metric in metrics]
+
+        return loss_fn(logits, y_test), metrics_value

--- a/jeta/models.py
+++ b/jeta/models.py
@@ -1,0 +1,137 @@
+from typing import List, Tuple
+
+import flax.linen as nn
+
+
+def MLP(dims: List[int], activations="relu") -> nn.Module:
+    """Create a multi-layer perceptron (MLP) module.
+    This consists of only Dense Layers followed by a relu activation.
+
+    Args:
+        dims (List[int]): dimentions of the MLP Layers.
+        activations (str, optional): Activation function to be used (relu, leaky relu, softmax, tanh). Defaults to 'relu'.
+
+    Returns:
+        nn.Module: Returns a Flax Module that can be used as a MLP.
+    """
+
+    if activations.lower() == "relu":
+        activation = nn.relu
+    elif activations.lower() == "leaky relu":
+        activation = nn.leaky_relu
+    elif activations.lower() == "softmax":
+        activation = nn.softmax
+    elif activations.lower() == "tanh":
+        activation = nn.tanh
+    else:
+        raise ValueError(
+            f"Invalid activation function\nExpected: (relu, leaky relu, softmax, tanh) but got: {activations}"
+        )
+
+    class Model(nn.Module):
+        @nn.compact
+        def __call__(self, x, train=True):
+            for dim in dims[:-1]:
+                x = nn.Dense(dim)(x)
+                x = activation(x)
+            x = nn.Dense(dims[-1])(x)
+            return x
+
+    mlp = Model()
+    return mlp
+
+
+def ConvBlock(
+    channels: int, kernel_size: Tuple[int], strides: Tuple[int], padding: str
+) -> nn.Module:
+    """Create a convolutional block module.
+    This consists of a convolution layer, batch normalization and a relu activation.
+
+    Args:
+        channels (int): Number of filters in the convolution layer.
+        kernel_size (Tuple[int]): Size of the convolution kernel.
+        strides (Tuple[int]): Strides of the convolution kernel.
+        padding (str): Padding of the convolution.
+
+    Returns:
+        nn.Module: Returns a Flax Module that can be used as a convolutional block.
+    """
+
+    class Model(nn.Module):
+        @nn.compact
+        def __call__(self, x, train=True):
+            x = nn.Conv(channels, kernel_size, strides, padding)(x)
+            x = nn.BatchNorm(use_running_average=not train)(x)
+            x = nn.relu(x)
+            return x
+
+    conv_block = Model()
+    return conv_block
+
+
+def CNN(dims: List[int]) -> nn.Module:
+    """Create a convolutional neural network (CNN) module.
+    Each Convolution block consists of a convolution layer, batch normalization and a relu activation.
+
+    Args:
+        dims (List[int]): Number of filters in each CNN layer.
+
+    Returns:
+        nn.Module: Returns a Flax Module that can be used as a CNN.
+    """
+
+    class Model(nn.Module):
+        @nn.compact
+        def __call__(self, x, train=True):
+            for dim in dims:
+                x = ConvBlock(dim, (3, 3), (1, 1), "SAME")(x, train)
+            return x
+
+    cnn = Model()
+    return cnn
+
+
+def RNN(dims: List[int], type: str = "lstm", activation: str = "relu") -> nn.Module:
+    """Create a recurrent neural network (RNN) module.
+    This consists of a Recurrent(LSTM, GRU) layer followed by a relu activation.
+
+    Args:
+        dims (List[int]): Number of units in the Recurrent layer.
+        type (str, optional): Type of the Recurrent layer(lstm, rnn). Defaults to 'lstm'.
+        activation (str, optional): Activation function to be used (relu, leaky relu, softmax, tanh). Defaults to 'relu'.
+
+    Returns:
+        nn.Module: Returns a Flax Module that can be used as a RNN.
+    """
+
+    if type.lower() == "lstm":
+        Cell = nn.OptimizedLSTMCell
+    elif type.lower() == "gru":
+        Cell = nn.GRUCell
+    else:
+        raise ValueError(f"Invalid type\nExpected: (lstm, gru) but got: {type}")
+
+    if activation.lower() == "relu":
+        activation = nn.relu
+    elif activation.lower() == "leaky relu":
+        activation = nn.leaky_relu
+    elif activation.lower() == "softmax":
+        activation = nn.softmax
+    elif activation.lower() == "tanh":
+        activation = nn.tanh
+    else:
+        raise ValueError(
+            f"Invalid activation function\nExpected: (relu, leaky relu, softmax, tanh) but got: {activation}"
+        )
+
+    class Model(nn.Module):
+        @nn.compact
+        def __call__(self, x, train=True):
+            for dim in dims[:-1]:
+                x = Cell(dim)(x)
+                x = activation(x)
+            x = nn.Cell(dims[-1])(x)
+            return x
+
+    rnn = Model()
+    return rnn


### PR DESCRIPTION
closes #25

### Example:

```python
from cnp import CNP, Aggregator

class Encoder(linen.Module):
    @linen.compact
    def __call__(self, x, y, train=True):
        # x : (n_classes * shots, 20)
        # y : (n_classes * shots, 1)
        
        y = y.squeeze() # (n_classes, )
        x = linen.Dense(32)(x)
        x = linen.relu(x)
        x = linen.Dense(64)(x)
        x = linen.relu(x)
        r = linen.Dense(32)(x) # (n_classes * shots, 32)

        aggregates = Aggregator.classification(r, y, ways)
        return aggregates # (ways * 32, )
```

```python
class Decoder(linen.Module):
    @linen.compact
    def __call__(self, r, x, train=True):
        # r : (ways * 32, )
        # x : (batch_size, 20)

        x = jax.vmap(lambda a, b: jnp.concatenate([a, b]), in_axes=(0, None))(x, r) # (batch_size, 20 + ways * 32)
        x = linen.Dense(32)(x)
        x = linen.relu(x)
        x = linen.Dense(64)(x)
        x = linen.relu(x)
        x = linen.Dense(32)(x)
        x = linen.relu(x)
        x = linen.Dense(ways)(x)
        return x
```
```python
key = jax.random.PRNGKey(0)
encoder_init_key, decoder_init_key = jax.random.split(key)

encoder = Encoder()
tx = optax.adam(1e-3)
params = encoder.init(encoder_init_key, jnp.ones((1, 20)), jnp.ones((1, 1)))
encoder_state = TrainState.create(apply_fn=encoder.apply, params=params, tx=tx)

decoder = Decoder()
params = decoder.init(decoder_init_key, jnp.ones((ways*32,)), jnp.ones((1, 20)))
decoder_state = TrainState.create(apply_fn=decoder.apply, params=params, tx=tx)
```

```python
n_epochs = 100
task_count=50
for epoch in range(n_epochs):
    # Sample and train on a batch of tasks
    # for task in range(task_count):
    tasks = sample_batch(meta_train_kloader, task_count)

    encoder_state, decoder_state, loss, metrics = CNP.meta_train_step(encoder_state, decoder_state, tasks, loss_fn=cross_entropy, metrics=(accuracy, ))
        
    print('Epoch  % 2d Loss: %2.5e Avg Acc: %2.5f'%(epoch+1, loss, metrics[0]))
    display.clear_output(wait=True)
```

cc: @veds12 